### PR TITLE
add the check when the input trustee_str is None

### DIFF
--- a/helpers/onefs_acl.py
+++ b/helpers/onefs_acl.py
@@ -358,7 +358,9 @@ def perms_to_text_list(perms, detailed=True):
 
 def trustees_txt_to_aces(trustee_str):
     aces = []
-    if trustee_str and not trustee_str.startswith("::trustee:"):
+    if not trustee_str:
+        return aces
+    if not trustee_str.startswith("::trustee:"):
         return aces
     trustee_list = trustee_str[10:].split("::trustee:")
     for trustee in trustee_list:

--- a/helpers/onefs_acl.py
+++ b/helpers/onefs_acl.py
@@ -29,8 +29,8 @@ SD_ACL_REGEX = (
     r"header:(revision:\d+)::(control:\d+)"
     r"::(owner:(?P<utype>UID|SID):(?P<user>\d+|S(-\d+)+))"
     r"::(group:(?P<gtype>GID|SID):(?P<group>\d+|S(-\d+)+))"
-    r"::->dacl<-:(?P<dacl>(rev:(?P<daclrev>\d+)::)?(?P<dacltrustees>::trustee.*))?"
-    r"::->sacl<-:(?P<sacl>(rev:(?P<saclrev>\d+)::)?(?P<sacltrustees>::trustee.*))?"
+    r"::->dacl<-:(rev:(?P<daclrev>\d+)::)?(?P<dacltrustees>::trustee.*)?"
+    r"::->sacl<-:(rev:(?P<saclrev>\d+)::)?(?P<sacltrustees>::trustee.*)?"
 )
 # fmt: off
 """ Mask bits for the trustee fields"""
@@ -307,9 +307,10 @@ def get_acl_dict(fd, detailed=True):
     sacl_aces = match.group("sacltrustees")
     if sacl_aces:
         acl_dict["sacl_aces"] = trustees_txt_to_aces(sacl_aces)
-    for ace in acl_dict["aces"]:
-        ace["flags_list"] = flags_to_text_list(ace["flags"])
-        ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
+    if acl_dict["aces"]:
+        for ace in acl_dict["aces"]:
+            ace["flags_list"] = flags_to_text_list(ace["flags"])
+            ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
     return acl_dict
 
 


### PR DESCRIPTION
```python
import os,sys,re
from helpers.onefs_acl import SD_ACL_REGEX, trustees_txt_to_aces, perms_to_text_list, flags_to_text_list

def test_sd_acl_regex(sd_str, detailed=True):
    match = re.match(SD_ACL_REGEX, sd_str)
    if not match:
        return {}
    acl_dict = {
        "aces": trustees_txt_to_aces(match.group("dacltrustees")),
        "group": match.group("group"),
        "group_type": match.group("gtype").lower(),
        "user": match.group("user"),
        "user_type": match.group("utype").lower(),
    }
    sacl_aces = match.group("sacltrustees")
    if sacl_aces:
        acl_dict["sacl_aces"] = trustees_txt_to_aces(sacl_aces)
    for ace in acl_dict["aces"]:
        ace["flags_list"] = flags_to_text_list(ace["flags"])
        ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
    return acl_dict

test_strs = [
"header:revision:1::control:32772::owner:UID:0::group:GID:0::->dacl<-:rev:2::::->sacl<-:",
"header:revision:1::control:32772::owner:UID:0::group:GID:0::->dacl<-:rev:2::::trustee:UID:0:0:2032127:0:0::trustee:GID:0:0:1179776:0:0::->sacl<-:",
"header:revision:1::control:34836::owner:UID:0::group:GID:0::->dacl<-:rev:2::::trustee:UID:1040:0:2032127:0:0::trustee:UID:0:0:1442207:0:0::trustee:GID:0:0:1179776:0:0::->sacl<-:rev:2::::trustee:UID:10:2:197055:64:0",
"header:revision:1::control:34836::owner:UID:0::group:GID:0::->dacl<-:rev:2::::->sacl<-:rev:2::::trustee:UID:10:2:197055:64:0",
"header:revision:1::control:32788::owner:SID:S-1-5-21-854245398-527237240-682003330-94009::group:SID:S-1-5-21-854245398-527237240-682003330-513::->dacl<-:::->sacl<-:rev:2::::trustee:SID:S-1-5-21-2995263512-2401593112-2846250759-1107:2:131241:64:0"
]

i = 1
for test_str in test_strs:
    print("Test case %d, sd_str = %s" %(i, test_str))
    i = i + 1
    acl_dict = test_sd_acl_regex(test_str)
    if not acl_dict:
        print("Test Fail: failed to parse %s" %(test_str))
    else:
        print(acl_dict)
    print("\n")
```

Test result:
```bash
fwu-mainhdfs-1# python test.py
Test case 1, sd_str = header:revision:1::control:32772::owner:UID:0::group:GID:0::->dacl<-:rev:2::::->sacl<-:
{'aces': [], 'group': '0', 'group_type': 'gid', 'user': '0', 'user_type': 'uid'}


Test case 2, sd_str = header:revision:1::control:32772::owner:UID:0::group:GID:0::->dacl<-:rev:2::::trustee:UID:0:0:2032127:0:0::trustee:GID:0:0:1179776:0:0::->sacl<-:
{'aces': [{'entity': '0', 'entity_type': 'uid', 'flags': 0, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 0, 'perm_type_str': 'allow', 'perms': 2032127, 'perms_list': ['append', 'delete_child', 'execute', 'file_read', 'file_write', 'gen_all', 'gen_read', 'gen_write', 'modify', 'read_attr', 'read_ext_attr', 'std_delete', 'std_read_dac', 'std_required', 'std_synchronize', 'std_write_dac', 'std_write_owner', 'write_attr', 'write_ext_attr']}, {'entity': '0', 'entity_type': 'gid', 'flags': 0, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 0, 'perm_type_str': 'allow', 'perms': 1179776, 'perms_list': ['read_attr', 'std_read_dac', 'std_synchronize']}], 'group': '0', 'group_type': 'gid', 'user': '0', 'user_type': 'uid'}


Test case 3, sd_str = header:revision:1::control:34836::owner:UID:0::group:GID:0::->dacl<-:rev:2::::trustee:UID:1040:0:2032127:0:0::trustee:UID:0:0:1442207:0:0::trustee:GID:0:0:1179776:0:0::->sacl<-:rev:2::::trustee:UID:10:2:197055:64:0
{'aces': [{'entity': '1040', 'entity_type': 'uid', 'flags': 0, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 0, 'perm_type_str': 'allow', 'perms': 2032127, 'perms_list': ['append', 'delete_child', 'execute', 'file_read', 'file_write', 'gen_all', 'gen_read', 'gen_write', 'modify', 'read_attr', 'read_ext_attr', 'std_delete', 'std_read_dac', 'std_required', 'std_synchronize', 'std_write_dac', 'std_write_owner', 'write_attr', 'write_ext_attr']}, {'entity': '0', 'entity_type': 'uid', 'flags': 0, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 0, 'perm_type_str': 'allow', 'perms': 1442207, 'perms_list': ['append', 'file_read', 'file_write', 'gen_read', 'gen_write', 'read_attr', 'read_ext_attr', 'std_read_dac', 'std_synchronize', 'std_write_dac', 'write_attr', 'write_ext_attr']}, {'entity': '0', 'entity_type': 'gid', 'flags': 0, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 0, 'perm_type_str': 'allow', 'perms': 1179776, 'perms_list': ['read_attr', 'std_read_dac', 'std_synchronize']}], 'group': '0', 'group_type': 'gid', 'user': '0', 'user_type': 'uid', 'sacl_aces': [{'entity': '10', 'entity_type': 'uid', 'flags': 64, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 2, 'perm_type_str': 'audit', 'perms': 197055, 'perms_list': []}]}


Test case 4, sd_str = header:revision:1::control:34836::owner:UID:0::group:GID:0::->dacl<-:rev:2::::->sacl<-:rev:2::::trustee:UID:10:2:197055:64:0
{'aces': [], 'group': '0', 'group_type': 'gid', 'user': '0', 'user_type': 'uid', 'sacl_aces': [{'entity': '10', 'entity_type': 'uid', 'flags': 64, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 2, 'perm_type_str': 'audit', 'perms': 197055, 'perms_list': []}]}


Test case 5, sd_str = header:revision:1::control:32788::owner:SID:S-1-5-21-854245398-527237240-682003330-94009::group:SID:S-1-5-21-854245398-527237240-682003330-513::->dacl<-:::->sacl<-:rev:2::::trustee:SID:S-1-5-21-2995263512-2401593112-2846250759-1107:2:131241:64:0
{'aces': [], 'group': 'S-1-5-21-854245398-527237240-682003330-513', 'group_type': 'sid', 'user': 'S-1-5-21-854245398-527237240-682003330-94009', 'user_type': 'sid', 'sacl_aces': [{'entity': 'S-1-5-21-2995263512-2401593112-2846250759-1107', 'entity_type': 'sid', 'flags': 64, 'flags_list': [], 'ifs_flags': 0, 'ifs_flags_list': [], 'perm_type': 2, 'perm_type_str': 'audit', 'perms': 131241, 'perms_list': []}]}


```