### PR TITLE
enhance flags_to_text_list and perms_to_text_list

### DIFF
--- a/libs/onefs_acl.py
+++ b/libs/onefs_acl.py
@@ -23,15 +23,17 @@ __all__ = [
 # fmt: on
 import os
 import re
+import functools
 from cffi import FFI
 
-SD_ACL_REGEX = (
+SD_ACL_REGEX = re.compile(
     r"header:(revision:\d+)::(control:\d+)"
     r"::(owner:(?P<utype>UID|SID):(?P<user>\d+|S(-\d+)+))"
     r"::(group:(?P<gtype>GID|SID):(?P<group>\d+|S(-\d+)+))"
     r"::->dacl<-:(rev:(?P<daclrev>\d+)::)?(?P<dacltrustees>::trustee.*)?"
     r"::->sacl<-:(rev:(?P<saclrev>\d+)::)?(?P<sacltrustees>::trustee.*)?"
 )
+
 # fmt: off
 """ Mask bits for the trustee fields"""
 # ===== ACE 'perms' mask bits
@@ -265,6 +267,10 @@ ACE_TYPE_FLAG_STR_MAP = {
     "254": "posix_mask",
 }
 
+ACE_GROUP_BITS_STR_DICT = {bitmask[0]: bitmask[1] for bitmask in ACE_GROUP_BITS_STR_MAP}
+ACE_SINGLE_BITS_STR_DICT = {bitmask[0]: bitmask[1] for bitmask in ACE_SINGLE_BITS_STR_MAP}
+ACE_FLAG_STR_DICT = {bitmask[0]: bitmask[1] for bitmask in ACE_FLAG_STR_MAP}
+
 try:
     ffi = FFI()
     ffi.cdef(
@@ -281,12 +287,27 @@ except:
     pass
 
 
+def simple_cache(maxsize):
+    def decorator(func):
+        cache = {}
+        @functools.wraps(func)
+        def wrapper(*args):
+            if args not in cache:
+                if len(cache) >= maxsize:
+                    cache.popitem()
+                cache[args] = func(*args)
+            return cache[args]
+        return wrapper
+    return decorator
+
+
+@simple_cache(maxsize=1024)
 def flags_to_text_list(flags):
     cur_bits = flags
     text_labels = []
-    for bitmask in ACE_FLAG_STR_MAP:
-        if cur_bits & bitmask[0] == bitmask[0]:
-            text_labels.append(bitmask[1])
+    for bitmask, label in ACE_FLAG_STR_DICT.items():
+        if cur_bits & bitmask == bitmask:
+            text_labels.append(label)
     return sorted(set(text_labels))
 
 
@@ -294,7 +315,7 @@ def get_acl_dict(fd, detailed=True):
     sd_str = get_sd_text(fd)
     if sd_str is None:
         return {}
-    match = re.match(SD_ACL_REGEX, sd_str)
+    match = SD_ACL_REGEX.match(sd_str)
     if not match:
         return {}
     acl_dict = {
@@ -340,19 +361,20 @@ def get_sd_text(fd):
     return retval
 
 
+@simple_cache(maxsize=1024)
 def perms_to_text_list(perms, detailed=True):
     cur_bits = perms
     group_mask = 0
     text_labels = []
-    for bitmask in ACE_GROUP_BITS_STR_MAP:
-        if cur_bits & bitmask[0] == bitmask[0]:
-            group_mask |= bitmask[0]
-            text_labels.append(bitmask[1])
+    for bitmask, label in ACE_GROUP_BITS_STR_DICT.items():
+        if cur_bits & bitmask == bitmask:
+            group_mask |= bitmask
+            text_labels.append(label)
     if group_mask and not detailed:
         cur_bits = cur_bits & ~group_mask
-    for bitmask in ACE_SINGLE_BITS_STR_MAP:
-        if cur_bits & bitmask[0] == bitmask[0]:
-            text_labels.append(bitmask[1])
+    for bitmask, label in ACE_SINGLE_BITS_STR_DICT.items():
+        if cur_bits & bitmask == bitmask:
+            text_labels.append(label)
     return sorted(set(text_labels))
 
 


### PR DESCRIPTION
I used the tool LineProfiler to test the execution time of each line in ```get_acl_dict```.

```python
fwu-950-332-1# python test_time.py
Total: 569105 files.
Timer unit: 1e-09 s

Total time: 111.75 s
File: /root/ps_scan/libs/onefs_acl.py
Function: get_acl_dict at line 293

Line #      Hits         Time  Per Hit   % Time  Line Contents
=============================================================
   293                                           def get_acl_dict(fd, detailed=True):
   294    569105        3e+10  55941.9     28.5      sd_str = get_sd_text(fd)
   295    569105  725421933.0   1274.7      0.6      if sd_str is None:
   296                                                   return {}
   297    569105 8392847890.0  14747.5      7.5      match = re.match(SD_ACL_REGEX, sd_str)
   298    569105  668681771.0   1175.0      0.6      if not match:
   299                                                   return {}
   300    569105  919880836.0   1616.4      0.8      acl_dict = {
   301    569105        2e+10  28678.0     14.6          "aces": trustees_txt_to_aces(match.group("dacltrustees")),
   302    569105  918419815.0   1613.8      0.8          "group": match.group("group"),
   303    569105  913900385.0   1605.9      0.8          "group_type": match.group("gtype").lower(),
   304    569105  801729047.0   1408.8      0.7          "user": match.group("user"),
   305    569105  875633927.0   1538.6      0.8          "user_type": match.group("utype").lower(),
   306                                               }
   307    569105  781860355.0   1373.8      0.7      sacl_aces = match.group("sacltrustees")
   308    569105  595037243.0   1045.6      0.5      if sacl_aces:
   309                                                   acl_dict["sacl_aces"] = trustees_txt_to_aces(sacl_aces)
   310   2268067 2632357964.0   1160.6      2.4      for ace in acl_dict.get("aces", []):
   311   1698962        1e+10   6854.0     10.4          ace["flags_list"] = flags_to_text_list(ace["flags"])
   312   1698962        3e+10  19521.8     29.7          ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
   313    569105  555461048.0    976.0      0.5      return acl_dict
```

Besides ```get_sd_text```, I found that I can add some enhancements on ```flags_to_text_list``` and ```perms_to_text_list```.

Test result from the LineProfiler:
Before:
```bash
fwu-950-332-1# python test_time.py
Total: 569105 files.
Timer unit: 1e-09 s

Total time: 111.75 s
File: /root/ps_scan/libs/onefs_acl.py
Function: get_acl_dict at line 293

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   293                                           def get_acl_dict(fd, detailed=True):
   294    569105        3e+10  55941.9     28.5      sd_str = get_sd_text(fd)
   295    569105  725421933.0   1274.7      0.6      if sd_str is None:
   296                                                   return {}
   297    569105 8392847890.0  14747.5      7.5      match = re.match(SD_ACL_REGEX, sd_str)
   298    569105  668681771.0   1175.0      0.6      if not match:
   299                                                   return {}
   300    569105  919880836.0   1616.4      0.8      acl_dict = {
   301    569105        2e+10  28678.0     14.6          "aces": trustees_txt_to_aces(match.group("dacltrustees")),
   302    569105  918419815.0   1613.8      0.8          "group": match.group("group"),
   303    569105  913900385.0   1605.9      0.8          "group_type": match.group("gtype").lower(),
   304    569105  801729047.0   1408.8      0.7          "user": match.group("user"),
   305    569105  875633927.0   1538.6      0.8          "user_type": match.group("utype").lower(),
   306                                               }
   307    569105  781860355.0   1373.8      0.7      sacl_aces = match.group("sacltrustees")
   308    569105  595037243.0   1045.6      0.5      if sacl_aces:
   309                                                   acl_dict["sacl_aces"] = trustees_txt_to_aces(sacl_aces)
   310   2268067 2632357964.0   1160.6      2.4      for ace in acl_dict.get("aces", []):
   311   1698962        1e+10   6854.0     10.4          ace["flags_list"] = flags_to_text_list(ace["flags"])
   312   1698962        3e+10  19521.8     29.7          ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
   313    569105  555461048.0    976.0      0.5      return acl_dict

Total time: 353.559 s
File: test_time.py
Function: get_all_files_in_directory at line 42

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    42                                           def get_all_files_in_directory():
    43                                               # Walk through the directory tree
    44         1       1606.0   1606.0      0.0      id = 0
    45     35834        1e+10 357520.0      3.6      for root, directories, files in os.walk(full_path):
    46    604938  805634458.0   1331.8      0.2          for filename in files:
    47                                                       # Create the full file path
    48    569105 7691860366.0  13515.7      2.2              file_path = os.path.join(root, filename)
    49    569105        3e+11 582081.3     93.7              scan_file(file_path)
    50    569105  985088115.0   1730.9      0.3              id += 1
    51         1      78082.0  78082.0      0.0      print("Total: %d files." %id)

fwu-950-332-1#
```

After:
```bash
fwu-950-332-1# python test_time.py
Total: 569105 files.
Timer unit: 1e-09 s

Total time: 70.8518 s
File: /root/ps_scan/libs/onefs_acl.py
Function: get_acl_dict at line 314

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   314                                           def get_acl_dict(fd, detailed=True):
   315    569105        3e+10  55899.0     44.9      sd_str = get_sd_text(fd)
   316    569105  723297385.0   1270.9      1.0      if sd_str is None:
   317                                                   return {}
   318    569105 4519601421.0   7941.6      6.4      match = SD_ACL_REGEX.match(sd_str)
   319    569105  690789707.0   1213.8      1.0      if not match:
   320                                                   return {}
   321    569105  918994973.0   1614.8      1.3      acl_dict = {
   322    569105        2e+10  28625.4     23.0          "aces": trustees_txt_to_aces(match.group("dacltrustees")),
   323    569105  924239775.0   1624.0      1.3          "group": match.group("group"),
   324    569105  906802492.0   1593.4      1.3          "group_type": match.group("gtype").lower(),
   325    569105  812207021.0   1427.2      1.1          "user": match.group("user"),
   326    569105  890815250.0   1565.3      1.3          "user_type": match.group("utype").lower(),
   327                                               }
   328    569105  825487969.0   1450.5      1.2      sacl_aces = match.group("sacltrustees")
   329    569105  587919886.0   1033.1      0.8      if sacl_aces:
   330                                                   acl_dict["sacl_aces"] = trustees_txt_to_aces(sacl_aces)
   331   2268067 2593054330.0   1143.3      3.7      for ace in acl_dict.get("aces", []):
   332   1698962 4082732471.0   2403.1      5.8          ace["flags_list"] = flags_to_text_list(ace["flags"])
   333   1698962 3721643815.0   2190.5      5.3          ace["perms_list"] = perms_to_text_list(ace["perms"], detailed)
   334    569105  550971836.0    968.1      0.8      return acl_dict

Total time: 305.849 s
File: test_time.py
Function: get_all_files_in_directory at line 42

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    42                                           def get_all_files_in_directory():
    43                                               # Walk through the directory tree
    44         1       1956.0   1956.0      0.0      id = 0
    45     35834        1e+10 358598.3      4.2      for root, directories, files in os.walk(full_path):
    46    604938  801481344.0   1324.9      0.3          for filename in files:
    47                                                       # Create the full file path
    48    569105 7919393552.0  13915.5      2.6              file_path = os.path.join(root, filename)
    49    569105        3e+11 497686.9     92.6              scan_file(file_path)
    50    569105 1041994292.0   1830.9      0.3              id += 1
    51         1      87232.0  87232.0      0.0      print("Total: %d files." %id)

fwu-950-332-1#
```

Test result from the whole ps_scan:
Before:
```bash
Final statistics
        Wall time (s): 5 minutes 13 seconds
        Average file/dir queue wait time (s): 0.12
        Average time spent in dir/file handler routines across all clients (s): 61.23 / 247.93
        Average dir scan time (s): 61.1
        Processed/Queued/Skipped dirs: 35,817 / 35,817 / 0
        Processed/Queued/Skipped files: 569,099 / 569,099 / 0
        Total file size/physical size: 22,508,599,960 (21.0 GiB)/ 26,525,523,968 (24.7 GiB)
        Avg files/second: 1,816.9
===== Custom stats (average over all threads) =====
{
  "es_queue_time": 0.17575696110725403,
  "es_queue_wait_count": 0,
  "file_not_found": 0,
  "get_access_time_time": 1.0759559273719788,
  "get_acl_time": 86.04935869574547,
  "get_custom_tagging_time": 0.0,
  "get_dinode_time": 5.031325966119766,
  "get_extra_attr_time": 0.0,
  "get_user_attr_time": 0.0,
  "lstat_required": 0,
  "lstat_time": 0.0
}
```
After:
```bash
Final statistics
        Wall time (s): 4 minutes 21 seconds
        Average file/dir queue wait time (s): 0.12
        Average time spent in dir/file handler routines across all clients (s): 60.04 / 197.10
        Average dir scan time (s): 59.9
        Processed/Queued/Skipped dirs: 35,817 / 35,817 / 0
        Processed/Queued/Skipped files: 569,099 / 569,099 / 0
        Total file size/physical size: 22,508,599,960 (21.0 GiB)/ 26,525,523,968 (24.7 GiB)
        Avg files/second: 2,178.8
===== Custom stats (average over all threads) =====
{
  "es_queue_time": 0.17155292630195618,
  "es_queue_wait_count": 0,
  "file_not_found": 0,
  "get_access_time_time": 1.0620339810848236,
  "get_acl_time": 70.50536933541298,
  "get_custom_tagging_time": 0.0,
  "get_dinode_time": 4.916044741868973,
  "get_extra_attr_time": 0.0,
  "get_user_attr_time": 0.0,
  "lstat_required": 0,
  "lstat_time": 0.0
}
```